### PR TITLE
Update xgboost to 1.3.0

### DIFF
--- a/runtime/py.yml
+++ b/runtime/py.yml
@@ -11,7 +11,7 @@ dependencies:
   - lightgbm=3.0.0=py38h950e882_0
   - loguru=0.5.0=py38h32f6830_0
   - pandas=1.1.2=py38h950e882_0
-  - py-xgboost=1.2.0=py38h32f6830_0
+  - py-xgboost=1.3.0=py38h578d9bd_0
   - pytest=6.0.2=py38h32f6830_0
   - python=3.8.5=h1103e12_8_cpython
   - python-dotenv=0.14.0=pyh9f0ad1d_0
@@ -20,7 +20,7 @@ dependencies:
   - scipy=1.5.2=py38h8c5af15_0
   - tensorflow=2.3
   - typer=0.3.1=py_0
-  - xgboost=1.2.0=py38h950e882_0
+  - xgboost=1.3.0=py38h709712a_0
   - cloudpickle=1.3.0
   - tsfresh=0.17.0
   - pytorch-lightning=1.1.2


### PR DESCRIPTION
**Reason**: xgboost 1.2.0 imports something from dask that requires a network
connection. This was changed by this [commit](https://github.com/dmlc/xgboost/commit/74ea82209b8eb42be411eb17f8336d2a447c5f9d) in 1.3.0 to only lazy import dask libraries.

My issue is similar to this [dask issue](https://github.com/dask/distributed/issues/4005). In particular, I get the following error when using the Docker container: 

`OSError: [Errno 101] Network is unreachable`

`make test-submission` works if I update xgboost from 1.2.0 to 1.3.0 in py.yml and if I go into the container using `make debug-container` and run main.py myself.  

Here is the full traceback:

```
Traceback (most recent call last):
  File "/home/appuser/miniconda/envs/py/lib/python3.8/site-packages/distributed/utils.py", line 136, in _get_ip
    sock.connect((host, port))
OSError: [Errno 101] Network is unreachable

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "main.py", line 181, in <module>
    typer.run(main)
  File "/home/appuser/miniconda/envs/py/lib/python3.8/site-packages/typer/main.py", line 855, in run
    app()
  File "/home/appuser/miniconda/envs/py/lib/python3.8/site-packages/typer/main.py", line 214, in __call__
    return get_command(self)(*args, **kwargs)
  File "/home/appuser/miniconda/envs/py/lib/python3.8/site-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "/home/appuser/miniconda/envs/py/lib/python3.8/site-packages/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "/home/appuser/miniconda/envs/py/lib/python3.8/site-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/appuser/miniconda/envs/py/lib/python3.8/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/home/appuser/miniconda/envs/py/lib/python3.8/site-packages/typer/main.py", line 497, in wrapper
    return callback(**use_params)  # type: ignore
  File "main.py", line 169, in main
    submission = main_loop(
  File "main.py", line 69, in main_loop
    from predict import predict_dst
  File "/codeexecution/predict.py", line 36, in <module>
    model_t0 = joblib.load(MODEL_PATH_t0)
  File "/home/appuser/miniconda/envs/py/lib/python3.8/site-packages/joblib/numpy_pickle.py", line 585, in load
    obj = _unpickle(fobj, filename, mmap_mode)
  File "/home/appuser/miniconda/envs/py/lib/python3.8/site-packages/joblib/numpy_pickle.py", line 504, in _unpickle
    obj = unpickler.load()
  File "/home/appuser/miniconda/envs/py/lib/python3.8/pickle.py", line 1210, in load
    dispatch[key[0]](self)
  File "/home/appuser/miniconda/envs/py/lib/python3.8/pickle.py", line 1535, in load_stack_global
    self.append(self.find_class(module, name))
  File "/home/appuser/miniconda/envs/py/lib/python3.8/pickle.py", line 1577, in find_class
    __import__(module, level=0)
  File "/home/appuser/miniconda/envs/py/lib/python3.8/site-packages/xgboost/__init__.py", line 9, in <module>
    from .core import DMatrix, DeviceQuantileDMatrix, Booster
  File "/home/appuser/miniconda/envs/py/lib/python3.8/site-packages/xgboost/core.py", line 19, in <module>
    from .compat import (
  File "/home/appuser/miniconda/envs/py/lib/python3.8/site-packages/xgboost/compat.py", line 173, in <module>
    from dask.distributed import Client, get_client
  File "/home/appuser/miniconda/envs/py/lib/python3.8/site-packages/dask/distributed.py", line 3, in <module>
    from distributed import *
  File "/home/appuser/miniconda/envs/py/lib/python3.8/site-packages/distributed/__init__.py", line 3, in <module>
    from .actor import Actor, ActorFuture
  File "/home/appuser/miniconda/envs/py/lib/python3.8/site-packages/distributed/actor.py", line 6, in <module>
    from .client import Future, default_client
  File "/home/appuser/miniconda/envs/py/lib/python3.8/site-packages/distributed/client.py", line 43, in <module>
    from .batched import BatchedSend
  File "/home/appuser/miniconda/envs/py/lib/python3.8/site-packages/distributed/batched.py", line 8, in <module>
    from .core import CommClosedError
  File "/home/appuser/miniconda/envs/py/lib/python3.8/site-packages/distributed/core.py", line 19, in <module>
    from .comm import (
  File "/home/appuser/miniconda/envs/py/lib/python3.8/site-packages/distributed/comm/__init__.py", line 26, in <module>
    _register_transports()
  File "/home/appuser/miniconda/envs/py/lib/python3.8/site-packages/distributed/comm/__init__.py", line 17, in _register_transports
    from . import inproc
  File "/home/appuser/miniconda/envs/py/lib/python3.8/site-packages/distributed/comm/inproc.py", line 75, in <module>
    global_manager = Manager()
  File "/home/appuser/miniconda/envs/py/lib/python3.8/site-packages/distributed/comm/inproc.py", line 39, in __init__
    self.ip = get_ip()
  File "/home/appuser/miniconda/envs/py/lib/python3.8/site-packages/distributed/utils.py", line 160, in get_ip
    return _get_ip(host, port, family=socket.AF_INET)
  File "cytoolz/functoolz.pyx", line 476, in cytoolz.functoolz._memoize.__call__
  File "/home/appuser/miniconda/envs/py/lib/python3.8/site-packages/distributed/utils.py", line 145, in _get_ip
    addr_info = socket.getaddrinfo(
  File "/home/appuser/miniconda/envs/py/lib/python3.8/socket.py", line 918, in getaddrinfo
    for res in _socket.getaddrinfo(host, port, family, type, proto, flags):
socket.gaierror: [Errno -3] Temporary failure in name resolution
```